### PR TITLE
Issue 18: configurable slash command in help text

### DIFF
--- a/config.js
+++ b/config.js
@@ -4,6 +4,9 @@ module.exports = {
   "host"   : "http://FIXME",
   "port"   : "8087",
 
+  // The slash command shown in help text, e.g., /stuart
+  "slash_command" : "stuart",
+
   // The Bot Persona
   "name"   : "Stuart",
   "emoji"  : ":construction_worker:",

--- a/lib/stuart.js
+++ b/lib/stuart.js
@@ -70,12 +70,12 @@ _Stuart.prototype.slash_command = function(request) {
     //
 	if( cmd === "help" ) {
 
-		var output = "Those crazy devs are always adding new tricks, but here's what I've got right now...The format is always '/stuart command' where command is one of the following :\n\n";
+		var output = "Those crazy devs are always adding new tricks, but here's what I've got right now...The format is always '/" + config.slash_command + " command' where command is one of the following :\n\n";
 		var stuart_commands = this.commands;
 		_.keys(this.commands).forEach(function(key) {
 			output += key + " - " + stuart_commands[key].name + "\n\n";
 		});
-		output += "\n\nIf you'd like to dig deeper, type '/stuart <command> help' for each of the individual commands";
+		output += "\n\nIf you'd like to dig deeper, type '/" + config.slash_command + " <command> help' for each of the individual commands";
 		this.slack_post(output, "@"+request.user_name);
 
 	} else {  // Service a slash command


### PR DESCRIPTION
Addressing Issue #18 by adding a new `slash_command` configuration item. Help text uses this value.