### PR TITLE
Issue #8 - Add default channel to the plugin configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,13 @@ To create a Cron task, you need to write one method - register() - and define th
 JSON spec :
 
     "inspire" : {
-        "active" : true,
+      "active" : true,
       "name" : "Inspiring messages",
       "hook" : "./plugins/cron/inspire",
       "author" : "greg",
-      "config" : {}
+      "config" : {
+        "channel" : "general"
+      }
     }
 
 The code implemented in the "hook" file (in this case, ./plugins/cron/inspire) :
@@ -114,7 +116,8 @@ The code implemented in the "hook" file (in this case, ./plugins/cron/inspire) :
 
     // in this example, positive_quote() is another internal function not shown here
     var cronTask = function() {
-        Stuart.slack_post("_"+positive_quote()+"_", '#general');
+        var plugin = this;
+        Stuart.slack_post("_"+positive_quote()+"_", '#'+plugin.config.channel);
     };
 
     module.exports.register = function() {

--- a/lib/plugins/cron/inspire.js
+++ b/lib/plugins/cron/inspire.js
@@ -66,7 +66,8 @@ var positive_quote = function() {
 };
 
 var cronTask = function() {
-	Stuart.slack_post("_"+positive_quote()+"_", '#general');
+	var plugin = this;
+	Stuart.slack_post("_"+positive_quote()+"_", '#'+plugin.config.channel);
 };
 
 module.exports.register = function() {

--- a/lib/plugins/cron/weather.js
+++ b/lib/plugins/cron/weather.js
@@ -58,7 +58,7 @@ var cronTask = function() {
             if( results.wSpeed > 18 ) {
                 output += "... and it's windy too! " + results.wSpeed + "mph.";
             }
-            Stuart.slack_post(output, '#general');
+            Stuart.slack_post(output, '#'+plugin.config.channel);
         });
     });
 };

--- a/lib/plugins/cron/worldcup.js
+++ b/lib/plugins/cron/worldcup.js
@@ -24,6 +24,7 @@ var match;
 
 var cronTask = function() {
       logme.debug('Fetching World Cup update...');
+	var plugin = this;
 
 	// Get Match list
 	requestify.get('http://live.mobileapp.fifa.com/api/wc/matches').then(function(response) {
@@ -50,7 +51,7 @@ var cronTask = function() {
             		// Notify New match
             		var text = 'Comienza '+match[homeTeamField]+ ' vs '+match[awayTeamField];
             		logme.debug(text);
-                        Stuart.slack_post(text, '#futbol');
+                        Stuart.slack_post(text, '#'+plugin.config.channel);
 
             	} else if (matchScore != match.c_Score) {
             		// Different Score
@@ -60,7 +61,7 @@ var cronTask = function() {
 
             		// Notify goal
             		logme.debug(text);
-                        Stuart.slack_post(text, '#futbol');
+                        Stuart.slack_post(text, '#'+plugin.config.channel);
             	}
 
             }

--- a/lib/plugins/plugins.json
+++ b/lib/plugins/plugins.json
@@ -63,7 +63,9 @@
 			"name" : "Inspiring messages",
 			"hook" : "./plugins/cron/inspire",
 			"author" : "greg",
-			"config" : {}
+			"config" : {
+			  "channel" : "general"
+			}
 		},
 
 		"weather" : {
@@ -72,6 +74,7 @@
 			"hook" : "./plugins/cron/weather",
 			"author" : "greg",
 		    "config" : {
+			  	"channel" : "general",
 		        "api_key" : "FIXME",
 		        "locations" : [
                     {
@@ -93,7 +96,9 @@
 			"name"   : "World Cup score updates",
 			"hook"   : "./plugins/cron/worldcup",
 			"author" : "greg",
-			"config" : {}
+			"config" : {
+			  "channel" : "futbol"
+			}
 		}
 	}
 }


### PR DESCRIPTION
* In each cron config block, added a "channel" key holding the channel name that was previously hard coded in each plugin.
* Replaced the hard coded channel name in each plugin with the use of the "channel" key from the plugin's config block.
* Updated README to reflect the new "channel" key in the plugin config.