### PR TITLE
Fix for 5 vulnerable dependency paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "express-session": "^1.13.0",
     "logme": "0.3.8",
     "method-override": "^2.3.5",
-    "request": "2.29.0",
+    "request": "2.74.0",
     "requestify": "0.1.17",
     "serve-favicon": "^2.3.0",
     "time": "0.11.4",


### PR DESCRIPTION
slack-stuart currently has a 9 vulnerable dependency paths, introducing 5 different types of known vulnerabilities.

This PR fixes vulnerable dependencies.
* [ReDOS vulnerability](https://snyk.io/vuln/npm:hawk:20160119) in the `hawk` dependency.
* [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency.
* [Denial of Service (Event Loop Blocking)](https://snyk.io/vuln/npm:qs:20140806-1) vulnerability in the `qs` dependency.
* [Denial of Service (Memory Exhaustion)](https://snyk.io/vuln/npm:qs:20140806) vulnerability in the `qs` dependency.

You can see [Snyk test report](https://snyk.io/test/github/gtracy/slack-stuart) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix the vulnerability listed above.
You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Note this PR fixes all the vulnerabilities introduced trough `request` dependency, in order to be vulnerability free you will need to upgrade `twilio` dependency as well.

Stay Secure,
The Snyk Team